### PR TITLE
feat: add remove webhooks from UI button

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,7 +48,6 @@ async def webhook(request: Request):
         'datetime': time.strftime("%Y-%m-%d %H:%M:%S")
     }
 
-    # Almacenar la petición
     peticiones_recibidas.insert(0, info_peticion)
 
     # Notificar a los websockets conectados
@@ -78,6 +77,19 @@ async def websocket_endpoint(websocket: WebSocket):
 @app.get("/api/peticiones")
 async def get_peticiones():
     return peticiones_recibidas
+
+
+@app.delete("/api/peticiones")
+async def delete_peticiones():
+    global peticiones_recibidas
+    peticiones_recibidas = []
+    
+    # Notificar a los websockets conectados que se han eliminado todas las peticiones
+    data = json.dumps({'event': 'clear_requests'})
+    for websocket in websockets_conectados:
+        await websocket.send_text(data)
+    
+    return {"message": "Todas las peticiones han sido eliminadas"}
 
 
 if __name__ == "__main__":

--- a/templates/index.html
+++ b/templates/index.html
@@ -122,6 +122,41 @@
             to {opacity: 0;}
         }
 
+        /* Estilos para el botón de eliminar */
+        .delete-button {
+            background-color: #dc3545;
+            color: white;
+            border: none;
+            padding: 8px 15px;
+            border-radius: 4px;
+            cursor: pointer;
+            margin-top: 10px;
+            font-weight: bold;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .delete-button:hover {
+            background-color: #c82333;
+        }
+
+        .delete-button:disabled {
+            background-color: #6c757d;
+            cursor: not-allowed;
+        }
+
+        .delete-icon {
+            margin-right: 5px;
+        }
+
+        .actions-container {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin: 15px 0;
+        }
+
     </style>
 </head>
 <body>
@@ -137,6 +172,15 @@
             <i class="copy-icon">📋</i>
         </div>
         <div id="copy-message" class="copy-message">Webhook copiado</div>
+        
+        <!-- Contenedor para acciones -->
+        <div class="actions-container">
+            <h2>Webhooks recibidos</h2>
+            <button id="delete-all-button" class="delete-button" onclick="eliminarTodasLasPeticiones()">
+                <span class="delete-icon">🗑️</span> Eliminar todos
+            </button>
+        </div>
+        
         <div id="lista-peticiones">
             <!-- Lista de peticiones se inserta aquí -->
         </div>
@@ -155,6 +199,7 @@
 <script>
     const listaPeticionesDiv = document.getElementById('lista-peticiones');
     const detallesPeticionDiv = document.getElementById('detalles-peticion');
+    const deleteAllButton = document.getElementById('delete-all-button');
     let peticionesRecibidas = [];
     
     // Variable para controlar si la recarga automática está activada
@@ -172,6 +217,7 @@
                     .then(data => {
                         peticionesRecibidas = data;
                         renderListaPeticiones();
+                        actualizarEstadoBotonEliminar();
                     })
                     .catch(error => console.error('Error al actualizar la lista:', error));
             }
@@ -263,6 +309,9 @@
             peticionDiv.onclick = () => mostrarDetallesPeticion(index);
             listaPeticionesDiv.appendChild(peticionDiv);
         });
+        
+        // Actualizar el estado del botón de eliminar
+        actualizarEstadoBotonEliminar();
     }
 
     // Función para mostrar los detalles de una petición en el panel derecho
@@ -279,6 +328,30 @@
             `;
     }
 
+    // Función para eliminar todas las peticiones
+    function eliminarTodasLasPeticiones() {
+        if (confirm('¿Estás seguro de que deseas eliminar todos los webhooks recibidos?')) {
+            fetch('/api/peticiones', {
+                method: 'DELETE'
+            })
+            .then(response => response.json())
+            .then(data => {
+                console.log('Respuesta del servidor:', data);
+                // La lista se actualizará automáticamente a través del WebSocket
+            })
+            .catch(error => console.error('Error al eliminar las peticiones:', error));
+        }
+    }
+
+    // Función para actualizar el estado del botón de eliminar
+    function actualizarEstadoBotonEliminar() {
+        if (peticionesRecibidas.length === 0) {
+            deleteAllButton.disabled = true;
+        } else {
+            deleteAllButton.disabled = false;
+        }
+    }
+
     // Configuración del WebSocket con protocolo adecuado
     const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
     const wsUrl = `${protocol}//${window.location.host}/ws`;
@@ -293,6 +366,11 @@
         if (data.event === 'new_request') {
             peticionesRecibidas.unshift(data.data);
             renderListaPeticiones();
+        } else if (data.event === 'clear_requests') {
+            peticionesRecibidas = [];
+            renderListaPeticiones();
+            // Limpiar los detalles si se estaban mostrando
+            detallesPeticionDiv.innerHTML = '<p>Selecciona una petición de la lista para ver sus detalles.</p>';
         }
     };
 


### PR DESCRIPTION
This pull request introduces a new feature to delete all received webhooks and updates the user interface to support this functionality. The most important changes include the addition of a new endpoint to delete all webhooks, updates to the HTML and CSS to add a delete button, and JavaScript functions to handle the delete action and update the button state.

### New feature: Delete all webhooks

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959R82-R94): Added a new endpoint `delete_peticiones` to clear all received webhooks and notify connected websockets.

### User interface updates

* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R125-R159): Added a delete button with styles and placed it in a new actions container. [[1]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R125-R159) [[2]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R175-R183)
* [`templates/index.html`](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R331-R354): Added JavaScript functions `eliminarTodasLasPeticiones` to handle the delete action and `actualizarEstadoBotonEliminar` to update the button state. [[1]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R331-R354) [[2]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R220) [[3]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R312-R314) [[4]](diffhunk://#diff-37a968442c22648ceb4a16069820cc5350b97e50f45f26c5442d7c036ad743d2R369-R373)

### Minor changes

* [`app.py`](diffhunk://#diff-568470d013cd12e4f388206520da39ab9a4e4c3c6b95846cbc281abc1ba3c959L51): Removed an outdated comment in the `webhook` function.